### PR TITLE
Fix color codes for grayscale mode

### DIFF
--- a/models/gdew042t2Grays.cpp
+++ b/models/gdew042t2Grays.cpp
@@ -256,20 +256,20 @@ void Gdew042t2Grays::fillScreen(uint16_t color)
     switch (color)
     {
       case EPD_BLACK:
-          b1 = 0xFF;
-          b2 = 0xFF;
+          b1 = 0x00;
+          b2 = 0x00;
       break;
       case EPD_LIGHTGREY:
-          b1 = 0xFF;
-          b2 = 0x00;
-      break;
-      case EPD_DARKGREY:
           b1 = 0x00;
           b2 = 0xFF;
       break;
-      case EPD_WHITE:
-          b1 = 0x00;
+      case EPD_DARKGREY:
+          b1 = 0xFF;
           b2 = 0x00;
+      break;
+      case EPD_WHITE:
+          b1 = 0xFF;
+          b2 = 0xFF;
       break;
     }
 
@@ -371,18 +371,18 @@ void Gdew042t2Grays::update()
   0x13|  01     00     01     00
   ****************/
   uint32_t bufindex = 0;
-  uint16_t bufferLenght = GDEW042T2_MONO_BUFFER_SIZE+1; // 15000
+  uint16_t bufferLength = GDEW042T2_MONO_BUFFER_SIZE+1; // 15000
   uint16_t bufferMaxSpi = 3000;
   uint8_t xbuf[bufferMaxSpi];
 
   IO.cmd(0x10); //1st buffer: SPI1
 
-  for(i=0;i<bufferLenght;i++)
+  for(i=0;i<bufferLength;i++)
 		{ 
         xbuf[bufindex] = _buffer1[i];
         // Flush SPI buffer
         if (i>0 && i % bufferMaxSpi == 0) {
-          //printf("10 sent part buff %d from *%d\n", bufindex,i);
+          // printf("10 sent part buff %lu from *%lu\n", bufindex,i);
           IO.data(xbuf, bufferMaxSpi);
           bufindex = 0;
         }
@@ -391,7 +391,7 @@ void Gdew042t2Grays::update()
   bufindex = 0;
 
   IO.cmd(0x13); //2nd buffer: SPI2
-  for(i=0;i<bufferLenght;i++)
+  for(i=0;i<bufferLength;i++)
 		{ 
         xbuf[bufindex] = _buffer2[i];
         // Flush SPI buffer


### PR DESCRIPTION
I found the cause of the issue I reported in #16. This has the fix, plus a minor spelling fix in a different function.