### PR TITLE
Fix off-by-one in gdey029T94 full refresh shifting image by one pixel

### DIFF
--- a/models/goodisplay/gdey029T94.cpp
+++ b/models/goodisplay/gdey029T94.cpp
@@ -109,7 +109,7 @@ void Gdey029T94::update()
     _wakeUp();
 
     IO.cmd(0x24); // write RAM1 for black(0)/white (1)
-    for (int y = GDEY029T94_HEIGHT; y >= 0; y--) {
+    for (int y = GDEY029T94_HEIGHT - 1; y >= 0; y--) {
       for (uint16_t x = 0; x < xLineBytes; x++)
       {
         uint16_t idx = y * xLineBytes + x;
@@ -128,7 +128,7 @@ void Gdey029T94::update()
     
     // 4 grays mode
     IO.cmd(0x24); // write RAM1 for black(0)/white (1)
-    for (int y = GDEY029T94_HEIGHT; y >= 0; y--) {
+    for (int y = GDEY029T94_HEIGHT - 1; y >= 0; y--) {
       for (uint16_t x = 0; x < xLineBytes; x++)
       {
         uint16_t idx = y * xLineBytes + x;
@@ -143,7 +143,7 @@ void Gdey029T94::update()
     }
     i = 0;
     IO.cmd(0x26); //RAM2 buffer: SPI2
-    for (int y = GDEY029T94_HEIGHT; y >= 0; y--) {
+    for (int y = GDEY029T94_HEIGHT - 1; y >= 0; y--) {
       for (uint16_t x = 0; x < xLineBytes; x++)
       {
         uint16_t idx = y * xLineBytes + x;


### PR DESCRIPTION
## Problem

The full refresh of the GDEY029T94 panel rendered the image shifted by exactly one pixel, while the partial refresh rendered correctly.

## Cause

In `Gdey029T94::update()` the row loops iterated starting at `GDEY029T94_HEIGHT` instead of `GDEY029T94_HEIGHT - 1`. Since the loop counts down to `0`, this processed one row beyond the buffer and offset the output by one pixel.

## Fix

Start the row loops at `GDEY029T94_HEIGHT - 1` in all three RAM write loops (0x24 black/white, 0x24 4-gray, 0x26 RAM2), matching the correct partial refresh behavior.

```
-    for (int y = GDEY029T94_HEIGHT; y >= 0; y--) {
+    for (int y = GDEY029T94_HEIGHT - 1; y >= 0; y--) {
```